### PR TITLE
Fix: Endless Icon Insertion at the Top of the File's Window

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "typing",
     "name": "Typing",
-    "version": "0.3.7",
+    "version": "0.3.8",
     "minAppVersion": "0.9.12",
     "description": "Programmatic customizations for groups of notes",
     "author": "Nikita Konodyuk",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-typing",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Strict note typing for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/src/middleware/title_bar.tsx
+++ b/src/middleware/title_bar.tsx
@@ -19,7 +19,7 @@ const ViewTitle = (props: { prefix: string | null; name: string | null; onNameCl
 
 function addViewActions(view: MarkdownView) {
     let actionsEl = view.containerEl.querySelector(".view-actions") as HTMLElement;
-    if (!actionsEl.querySelector(`a.view-action[aria-label="Actions"]`)) {
+    if (!actionsEl.querySelector(`button.view-action[aria-label="Actions"]`)) {
         view.addAction("layout-grid", "Actions", () => {
             let note = gctx.api.note(view.file.path);
             new ActionSuggestModal(gctx.app, note).open();


### PR DESCRIPTION
Closes #22

---
### What is changed?
The condition is trying to match an `a` element with a `viewActions` class and `aria-label="Actions"`. However, this does not match, since the elements in the viewActions are of type `button`. At least, in my version of Obsidian (v1.6.7).
![image](https://github.com/user-attachments/assets/60c5a6aa-483f-497c-9887-9ea0ce0a3b11)

Changing `a` to `button` seems to fix the problem for me. To verify that, I made the change in `.obsidian\plugins\typing\main.js` on line `163363` of the installed plugin.

Before change:
![image](https://github.com/user-attachments/assets/c7b8c8c9-615f-4525-9d1b-9266a971c99d)

After change:
![image](https://github.com/user-attachments/assets/2ac8a48f-bfa6-4562-b81e-f9bc06182ddd)